### PR TITLE
feat: adds the bug bounty leaderboard

### DIFF
--- a/content/bugbounty/index.md
+++ b/content/bugbounty/index.md
@@ -57,3 +57,16 @@ Visit the <a href="https://spec.filecoin.io/#intro__implementations-status" targ
 
  - Filecoin’s core development team, employees of Protocol Labs, the Filecoin Foundation and others paid by these organizations to work on the Filecoin project, indirectly or directly, are not eligible for bug bounty rewards.
 
+#### Leaderboard
+
+ | | Bounty Hunter |   GitHub User         | Reward  |
+ |-| ------------- |:-------------:| -----:|
+ |1| Wei Yang      | [@waynewyang](https://github.com/waynewyang) | 0000 pts |
+ |2| Leo Zhang     | [@Leozhang404](https://github.com/Leozhang404) | 0000 pts |
+
+
+#### News and Updates
+
+- **July 2020** - [Wei Yang](https://github.com/waynewyang) found a bug in `ConsensusFaultTimeOffsetMining` that could lead to incorrectly declared faults. [Mitigation](https://github.com/filecoin-project/lotus/pull/1988)
+- **July 2020** - [Wei Yang](https://github.com/waynewyang) found an issue with the `ReportConsensusFault` function caused it to not take effect. [Mitigation](https://github.com/filecoin-project/lotus/issues/1981)
+- **May 2020** - [Leo Zhang](https://github.com/Leozhang404) found that a message that could make the global cron actor's `HandleProvingPeriod` method crash. [Mitigation](https://github.com/filecoin-project/specs-actors/pull/383)


### PR DESCRIPTION
Provided by @eshon.

Preview (obviously this will look a bit different when https://github.com/filecoin-project/website-security.filecoin.io/pull/1 is merged!):

<img width="654" alt="Screenshot 2020-10-14 at 21 35 34" src="https://user-images.githubusercontent.com/152863/96042357-36def800-0e65-11eb-8815-03d2dd5e84a9.png">

Will these users eventually get rewards @dkkapur?
