### PR TITLE
Fix GitHub spelling

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -75,7 +75,7 @@ image = "images/2020-landscape-1-2.jpg"
 title = "Filecoin Security"
 content = "The Filecoin Security program is part of the The Filecoin project. It encourages responsible vulnerability research and disclosure."
 
-github = "[filecoin-project Org on on Github](https://github.com/filecoin-project)"
+github = "[filecoin-project Org on on GitHub](https://github.com/filecoin-project)"
 spec = "[Specification of the Filecoin protocol](https://spec.filecoin.io)"
 
 copyright = "[Filecoin](https://filecoin.io)"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -31,7 +31,7 @@
       <div class="wp-block-group alignwide">
         <div class="wp-block-group__inner-container">
           <h2 class="has-text-align-center">Vulnerability Reporting</h2>
-          <p class="entry-content main">Almost anything you find that is a bug in the codebase should be filed as an issue on Github. However, when you find a bug that is also a security vulnerability and can compromise the integrity of the live network, please bring it to our attention right away.</p>
+          <p class="entry-content main">Almost anything you find that is a bug in the codebase should be filed as an issue on GitHub. However, when you find a bug that is also a security vulnerability and can compromise the integrity of the live network, please bring it to our attention right away.</p>
           <p class="entry-content main"><strong>We’ve created two main channels for reporting:</strong></p>
           <ul class="entry-content main">
             <li>Send an email to <a href = "mailto:security@filecoin.org">security@filecoin.org</a>. This email is monitored everyday. Please use <a href="https://github.com/filecoin-project/community/blob/master/public.key" target="_blank">our PGP key</a> to encrypt sensitive information.</li>

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -87,7 +87,7 @@
 
   {{ with .Site.Params.social.github }}
   <li id="menu-item-44" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-44"><a
-      href="{{ . | safeURL }}"><span class="screen-reader-text">Github</span><svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+      href="{{ . | safeURL }}"><span class="screen-reader-text">GitHub</span><svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
       width="24px" height="24px" viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
    <style type="text/css">
      .st0{display:none;fill:#FFFFFF;}


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.